### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -30,6 +32,8 @@ jobs:
     name: Build release binaries
     needs: create-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         target:


### PR DESCRIPTION
Potential fix for [https://github.com/obstreperous-ai/sql-loader-rust/security/code-scanning/3](https://github.com/obstreperous-ai/sql-loader-rust/security/code-scanning/3)

Add explicit `permissions` at the **job level** so each job gets only what it needs:

- `create-release` needs to create a GitHub release → `contents: write`.
- `build-release` needs to upload release assets to that release → `contents: write`.

This is the safest no-behavior-change fix for the shown workflow because both jobs already rely on release write operations via `GITHUB_TOKEN`.  
Edit `.github/workflows/release.yml` by inserting `permissions:` blocks under each job (`create-release` and `build-release`) directly below `runs-on` (or near other job metadata).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
